### PR TITLE
Add initial Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM adzerk/boot-clj:latest
+ADD ./ /boot-clj
+WORKDIR /boot-clj
+# Pull deps in the build phase, this takes awhile
+RUN boot show -d
+ENTRYPOINT ["/usr/bin/boot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM adzerk/boot-clj:latest
-ADD ./ /boot-clj
-WORKDIR /boot-clj
-# Pull deps in the build phase, this takes awhile
-RUN boot show -d
-ENTRYPOINT ["/usr/bin/boot"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM adzerk/boot-clj:latest
+ADD ./ /clj-docs
+WORKDIR /clj-docs
+# Pull deps in the build phase, this takes awhile
+RUN boot show -d
+ENTRYPOINT ["/usr/bin/boot"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,5 @@ ADD ./ /clj-docs
 WORKDIR /clj-docs
 # Pull deps in the build phase, this takes awhile
 RUN boot show -d
+VOLUME ["/clj-docs/target"]
 ENTRYPOINT ["/usr/bin/boot"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,12 +13,15 @@ To build this container, run:
 
 To generate documents for a jar, run:
 
-`$ docker run -it clj-docs:latest -p {clojure-project-name} -v {clojure-project-version}`
+`$ docker run -it clj-docs:latest -p {clojure-project-name} -v {clojure-project-version} target`
 
 The clojure project name is `{project-group-id}/{project-name}`, for example: `org.clojure/clojure`
 
 The clojure project version is a clojure project version string, for example `1.0.0`
 
-## Copying Generated Docs
+## Accessing Generated Docs
 
-TODO
+This mounts a directory on the host machine into the docker container, where generated
+files will be placed. This can be done by running the following
+
+`$ docker run --mount type=bind,source={directory-to-mount},destination=/clj-docs/target clj-docs:latest -p {clojure-project-name} -v {clojure-project-version} target`

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# clj-docs in docker
+
+This dockerfile allows us to generate docs for a jar in isolation, evaluating
+untrusted code in a contained environment.
+
+## Building
+
+To build this container, run:
+
+`$ docker build -t clj-docs:latest -f docker/Dockerfile .`
+
+## Running
+
+To generate documents for a jar, run:
+
+`$ docker run -it clj-docs:latest -p {clojure-project-name} -v {clojure-project-version}`
+
+The clojure project name is `{project-group-id}/{project-name}`, for example: `org.clojure/clojure`
+
+The clojure project version is a clojure project version string, for example `1.0.0`
+
+## Copying Generated Docs
+
+TODO


### PR DESCRIPTION
Currently, this Dockerfile:

- Mounts the repo we run build from to boot-clj
- Pulls all deps that clj-docs needs to run analysis

Tested against a couple of jars to ensure docs generate properly.

As far as getting documents out of the container we can either mount a volume or call `docker cp` to copy them out.