### PR TITLE
Add --rm switch to remove stopped containers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,13 +16,8 @@ $ docker build -t cljdoc:latest -f docker/Dockerfile .
 To generate documents for a `[bidi "2.1.3"]`, run:
 
 ```sh
-$ docker run -it cljdoc:latest build-docs --project bidi --version 2.1.3 target
+$ docker run --rm cljdoc:latest build-docs --project bidi --version 2.1.3 target
 ```
-
-**TODO** Running docker images causes a lot of stopped containers to
-stick around. Stopped containers prevent deletion of images and we probably
-don't need them anyway. Document how we can run an image and delete
-the container right after it finished running.
 
 ## Accessing Generated Docs
 
@@ -32,6 +27,6 @@ files will be placed. This can be done by running the following
 ```sh
 $ mkdir -p docker/docker-target
 $ export DOCKER_TARGET=$(pwd)/docker/docker-target
-$ docker run --mount type=bind,source=$DOCKER_TARGET,destination=/cljdoc/target \
+$ docker run --rm --mount type=bind,source=$DOCKER_TARGET,destination=/cljdoc/target \
       cljdoc:latest build-docs --project bidi --version 2.1.3 target
 ```


### PR DESCRIPTION
The current suggested commands for running the container leave stopped containers, which can be solved by adding the `--rm` flag when we run the containers.

- [x] Add flag
- [x] Ensure mounted directory still works