### PR TITLE
Add SSH agent authentication support

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -29,6 +29,8 @@
 
     [org.slf4j/slf4j-nop "1.7.25"]
     [org.eclipse.jgit "4.10.0.201712302008-r"]
+    [com.jcraft/jsch.agentproxy.connector-factory "0.0.9"]
+    [com.jcraft/jsch.agentproxy.jsch "0.0.9"]
 
     [org.clojure-grimoire/lib-grimoire "0.10.9"]
     ;; lib-grimpoire depends on an old core-match


### PR DESCRIPTION
This is based on the implementation in gitlibs, and should function very
similarly.

Documentation:

> ssh authentication works by connecting to the local ssh agent (ssh-agent on
> *nix or Pageant via PuTTY on Windows). The ssh-agent must have a registered
> identity for the key being used to access the Git repository. To check whether
> you have registered identities, use:
> ssh-add -l
> which should return one or more registered identities, typically the one at ~/.ssh/id_rsa.

----

I've perhaps not tested this as thoroughly as it requires.