### PR TITLE
Use zprint to format arglists to fit within available space.

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -42,7 +42,8 @@
     [ragtime "0.7.2"]
 
     [expound "0.6.0"]
-    [metosin/bat-test "0.4.0" :scope "test"]])
+    [metosin/bat-test "0.4.0" :scope "test"]
+    [zprint "0.4.9"]])
 
 (boot.core/set-env! :source-paths #{"src" "test"}
                     :resource-paths #{"resources"}

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -7,7 +7,8 @@
             [cljdoc.spec]
             [cljdoc.routes :as routes]
             [clojure.string :as string]
-            [hiccup2.core :as hiccup]))
+            [hiccup2.core :as hiccup]
+	    [zprint.core :as zp]))
 
 (defn def-code-block
   [content]
@@ -33,7 +34,12 @@
      ;;   [:code (pr-str def-meta)])
      [:div.lh-copy
       (for [argv (sort-by count (:arglists def-meta))]
-        (def-code-block (str "(" (:name def-meta) (when (seq argv) " ") (string/join " " argv) ")")))]
+        (def-code-block 
+	  (zp/zprint-str (str "(" 
+	                      (:name def-meta) 
+			      (when (seq argv) " ") 
+			      (string/join " " argv) ")")
+			 {:parse-string? true :width 70})))]
      (when (:doc def-meta)
        [:div.lh-copy.markdown
         (-> (:doc def-meta) rich-text/markdown-to-html hiccup/raw)])


### PR DESCRIPTION
As written, this uses a hard-coded 70 column width, since that seems to be about the available space.  The default of 80 was definitely too big, things were still cut off.  If there is some configuration for width of the html output, I'd be happy to integrate with that.  I tested this on generating API documentation for zprint itself (which has some pretty big arglists) and they came out fine.

Oh, one small thing.  The latest repo I cloned failed when I ran it because there was no `data` directory, but once I created it by hand, it worked fine.  That seems to be a new thing, as the previous version I tried this on didn't have that problem.  No big deal, the error is quite clear.