### PR TITLE
@alex-dixon/@timothypratley: adds maven central as a repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ops/.terraform
 ops/terraform.tfstate*
 ops/image/image-id
 ops/prod-backup/
+.idea
+*.iml
+project.clj

--- a/build.boot
+++ b/build.boot
@@ -61,7 +61,7 @@
          '[cljdoc.config :as cfg]
          '[cljdoc.analysis.task :as ana]
          '[cljdoc.util]
-         '[cljdoc.util.clojars :as clojars]
+         '[cljdoc.util.repositories :as repositories]
          '[cljdoc.util.boot])
 
 (spec/check-asserts true)
@@ -105,8 +105,8 @@
    v version VERSION str "Version of project to build documentation for"]
   (comp (ana/analyze :project project
                      :version version
-                     :jarpath (:jar (clojars/artifact-uris project version))
-                     :pompath (:pom (clojars/artifact-uris project version)))
+                     :jarpath (:jar (repositories/artifact-uris project version))
+                     :pompath (:pom (repositories/artifact-uris project version)))
         (grimoire :project project :version version)
         (grimoire-html :project project :version version)
         (sift :move {#"^public/" "grimoire-html/"})))

--- a/src/cljdoc/render/build_req.clj
+++ b/src/cljdoc/render/build_req.clj
@@ -1,7 +1,7 @@
 (ns cljdoc.render.build-req
   "HTML pages/fragments related to requesting a documentation build"
   (:require [cljdoc.render.layout :as layout]
-            [cljdoc.util.clojars :as clojars]
+            [cljdoc.util.repositories :as repositories]
             [cljdoc.util :as util]
             [aleph.http :as http]))
 
@@ -9,7 +9,7 @@
   (->> [:div.pa4-ns.pa2
         [:h1 "Want to build some documentation?"]
         [:p "We currently don't have documentation built for " (util/clojars-id route-params) " v" (:version route-params)]
-        (if (clojars/artifact-uris (util/clojars-id route-params) (:version route-params))
+        (if (repositories/artifact-uris (util/clojars-id route-params) (:version route-params))
           [:form.pv3 {:action "/api/request-build2" :method "POST"}
            [:input.pa2.mr2.br2.ba.outline-0.blue {:type "text" :id "project" :name "project" :value (str (:group-id route-params) "/" (:artifact-id route-params))}]
            [:input.pa2.mr2.br2.ba.outline-0.blue {:type "text" :id "version" :name "version" :value (:version route-params)}]

--- a/src/cljdoc/render/build_req.clj
+++ b/src/cljdoc/render/build_req.clj
@@ -9,7 +9,7 @@
   (->> [:div.pa4-ns.pa2
         [:h1 "Want to build some documentation?"]
         [:p "We currently don't have documentation built for " (util/clojars-id route-params) " v" (:version route-params)]
-        (if (clojars/on-clojars? (util/clojars-id route-params) (:version route-params))
+        (if (clojars/artifact-uris (util/clojars-id route-params) (:version route-params))
           [:form.pv3 {:action "/api/request-build2" :method "POST"}
            [:input.pa2.mr2.br2.ba.outline-0.blue {:type "text" :id "project" :name "project" :value (str (:group-id route-params) "/" (:artifact-id route-params))}]
            [:input.pa2.mr2.br2.ba.outline-0.blue {:type "text" :id "version" :name "version" :value (:version route-params)}]

--- a/src/cljdoc/server/api.clj
+++ b/src/cljdoc/server/api.clj
@@ -5,7 +5,7 @@
             [cljdoc.server.ingest :as ingest]
             [cljdoc.server.build-log :as build-log]
             [cljdoc.util]
-            [cljdoc.util.clojars :as clojars]
+            [cljdoc.util.repositories :as repositories]
             [cljdoc.cache]
             [cljdoc.config] ; should not be necessary but instead be passed as args
             [cljdoc.renderers.html :as html]
@@ -107,7 +107,7 @@
                          version   (get-in ctx [:parameters :form :version])
                          ;; WARN this introduces some coupling to clojars, making it a little
                          ;; less easy to build documentation for artifacts only existing in local ~/.m2
-                         a-uris    (clojars/artifact-uris project version)
+                         a-uris    (repositories/artifact-uris project version)
                          build-id  (build-log/analysis-requested!
                                     build-tracker
                                     (cljdoc.util/group-id project)

--- a/src/cljdoc/util.clj
+++ b/src/cljdoc/util.clj
@@ -5,7 +5,8 @@
   should work without any additional dependencies."
   (:require [clojure.edn]
             [clojure.java.io :as io]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [boot.pod :as pod])
   (:import (java.nio.file Files)))
 
 (def hardcoded-config
@@ -37,7 +38,7 @@
 
 (defn local-jar-file [[project version :as coordinate]]
   ;; (jar-file '[org.martinklepsch/derivatives "0.2.0"])
-  (->> (boot.pod/resolve-dependencies {:dependencies [coordinate]})
+  (->> (pod/resolve-dependencies {:dependencies [coordinate]})
        (filter #(if (.endsWith version "-SNAPSHOT")
                   (= project (first (:dep %)))
                   (= coordinate (:dep %))))

--- a/src/cljdoc/util/repositories.clj
+++ b/src/cljdoc/util/repositories.clj
@@ -1,4 +1,4 @@
-(ns cljdoc.util.clojars
+(ns cljdoc.util.repositories
   (:require [cljdoc.util :as util]
             [clojure.string :as string]
             [aleph.http :as http]
@@ -8,6 +8,7 @@
   (:import (org.jsoup Jsoup)
            (java.time Instant Duration)))
 
+; TODO. Maven Central
 (defn releases-since [inst]
   (let [req @(http/get "https://clojars.org/search"
                        {;:throw-exceptions? false

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -1,14 +1,29 @@
 (ns cljdoc.util-test
   (:require [cljdoc.util :as util]
-            [clojure.test :as t]))
+            [cljdoc.util.repositories :as repositories]
+            [clojure.test :as t])
+  (:import (clojure.lang ExceptionInfo)))
 
 (t/deftest gh-coordinate-test
   (t/is (= "circleci" (util/gh-owner "https://github.com/circleci/clj-yaml")))
   (t/is (= "clj-yaml" (util/gh-repo "https://github.com/circleci/clj-yaml")))
   (t/is (= "circleci/clj-yaml" (util/gh-coordinate "https://github.com/circleci/clj-yaml"))))
 
+(t/deftest find-artifact-repository-test
+  (t/is (= (repositories/find-artifact-repository "org.clojure/clojure" "1.9.0")
+           (:maven-central repositories/repositories)))
+  (t/is (false? (repositories/exists? (:clojars repositories/repositories) 'bidi "2.1.3-SNAPSHOT")))
+  (t/is (true? (repositories/exists? (:clojars repositories/repositories) 'bidi "2.0.9-SNAPSHOT")))
+  (t/is (thrown-with-msg? ExceptionInfo #"Requested version cannot be found on Clojars or Maven Central"
+                          (repositories/artifact-uris 'bidi "2.1.3-SNAPSHOT")))
+  (t/is (= (repositories/artifact-uris 'bidi "2.0.9-SNAPSHOT")
+           {:pom "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.pom",
+            :jar "https://repo.clojars.org/bidi/bidi/2.0.9-SNAPSHOT/bidi-2.0.9-20160426.224252-1.jar"})))
+
+
+
+
 (comment
   (t/run-tests)
-
 
   )


### PR DESCRIPTION
Clojure is not hosted on Clojars.
Including Maven Central in the repositories list allows Clojure to be
documented. Note that clojure.parallel fails, but the docs are still
generated for other namespaces. clojure.parallel is deprecated.