### PR TITLE
track errors in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
           - v1-dependencies-{{ checksum "build.boot" }}
           - v1-dependencies- # fallback if not cache found
 
-      - run: cp resources/config.template.edn resources/config.edn
       - run: boot show -d
       - run: boot -B -d codox
 

--- a/build.boot
+++ b/build.boot
@@ -38,6 +38,7 @@
     [io.pedestal/pedestal.jetty         "0.5.3"]
     [cheshire "5.8.0"]
     [aleph "0.4.5-alpha6"] ;TODO replace with clj-http or similar
+    [raven-clj "1.5.2"]
 
     ;; Build-logs DB (sqlite)
     [org.xerial/sqlite-jdbc "3.20.0"]

--- a/build.boot
+++ b/build.boot
@@ -38,7 +38,7 @@
     [io.pedestal/pedestal.jetty         "0.5.3"]
     [cheshire "5.8.0"]
     [aleph "0.4.5-alpha6"] ;TODO replace with clj-http or similar
-    [raven-clj "1.5.2"]
+    [raven-clj "1.6.0-alpha"]
 
     ;; Build-logs DB (sqlite)
     [org.xerial/sqlite-jdbc "3.20.0"]

--- a/ops/create-secrets.cljs
+++ b/ops/create-secrets.cljs
@@ -19,7 +19,7 @@
               :r53-hosted-zone (tf-val tf-outputs "cloudfront_url")}
         :circle-ci {:api-token js/process.env.CIRCLE_API_TOKEN
                     :builder-project js/process.env.CIRCLE_BUILDER_PROJECT}
-
+        :sentry {:dsn js/process.env.SENTRY_DSN}
         :telegram {:bot-token js/process.env.TELEGRAM_BOT_TOKEN
                    :chat-id js/process.env.TELEGRAM_CHAT_ID}}))
 

--- a/ops/run-cljdoc-api.sh
+++ b/ops/run-cljdoc-api.sh
@@ -18,4 +18,4 @@ fi
 pushd "cljdoc-$version"
 
 echo "Starting process"
-CLJDOC_PROFILE=prod CLJDOC_ANALYSIS_SERVICE=circle-ci BOOT_JVM_OPTIONS=-Xmx1400m boot run
+CLJDOC_PROFILE=prod BOOT_JVM_OPTIONS=-Xmx1400m boot run

--- a/ops/run-cljdoc-api.sh
+++ b/ops/run-cljdoc-api.sh
@@ -18,4 +18,4 @@ fi
 pushd "cljdoc-$version"
 
 echo "Starting process"
-CLJDOC_PROFILE=prod BOOT_JVM_OPTIONS=-Xmx1400m boot run
+CLJDOC_PROFILE=prod CLJDOC_VERSION="$version" BOOT_JVM_OPTIONS=-Xmx1400m boot run

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -10,6 +10,8 @@
                                              :prod :circle-ci}
                  :autobuild-clojars-releases? #profile {:default false
                                                         :prod true}
+                 :enable-sentry? #profile {:default false
+                                           :prod true}
                  :dir #profile {:default "data/"
                                 :prod "/var/cljdoc/"}}
  :cljdoc/hardcoded #include "hardcoded-projects-config.edn"}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -5,7 +5,8 @@
  :cljdoc/server {:port 8000
                  :host #profile {:prod "cljdoc.xyz"
                                  :default "localhost"}
-                 :analysis-service #keyword #or [#env CLJDOC_ANALYSIS_SERVICE :local]
+                 :analysis-service #profile {:default :local
+                                             :prod :circle-ci}
                  :autobuild-clojars-releases? #profile {:default false
                                                         :prod true}
                  :dir #profile {:default "data/"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,6 +2,7 @@
 {:secrets #profile {:prod #include #join [ #env HOME "/secrets.edn"]
                     :live #include "secrets.edn"
                     :local {}}
+ :cljdoc/version #env CLJDOC_VERSION
  :cljdoc/server {:port 8000
                  :host #profile {:prod "cljdoc.xyz"
                                  :default "localhost"}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,7 +2,7 @@
 {:secrets #profile {:prod #include #join [ #env HOME "/secrets.edn"]
                     :live #include "secrets.edn"
                     :local {}}
- :cljdoc/version #env CLJDOC_VERSION
+ :cljdoc/version #or [#env CLJDOC_VERSION "dev"]
  :cljdoc/server {:port 8000
                  :host #profile {:prod "cljdoc.xyz"
                                  :default "localhost"}

--- a/resources/config.min.edn
+++ b/resources/config.min.edn
@@ -1,3 +1,0 @@
-{:cljdoc/server {:analysis-service :local}
- :cljdoc/hardcoded #include "hardcoded-projects-config.edn"}
-

--- a/resources/config.template.edn
+++ b/resources/config.template.edn
@@ -1,5 +1,0 @@
-{:secrets #include "secrets.edn"
- :cljdoc/server {:port 8000,
-                 :dir "./tmp"
-                 :analysis-service :local}
- :cljdoc/hardcoded #include "hardcoded-projects-config.edn"}

--- a/resources/secrets.edn
+++ b/resources/secrets.edn
@@ -4,4 +4,5 @@
        :cloudfront-id #env CLOUDFRONT_ID
        :cloudfront-url #env CLOUDFRONT_URL
        :r53-hosted-zone #env ROUTE53_HOSTED_ZONE}
- :circle-ci {:api-token #env CIRCLE_API_TOKEN}}
+ :circle-ci {:api-token #env CIRCLE_API_TOKEN}
+ :sentry {:dsn #env SENTRY_DSN}}

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -47,6 +47,10 @@
   ([] (autobuild-clojars-releases? (config)))
   ([config] (get-in config [:cljdoc/server :autobuild-clojars-releases?])))
 
+(defn version
+  ([] (version (config)))
+  ([config] (get-in config [:cljdoc/version])))
+
 (comment
   (config)
 

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -15,7 +15,7 @@
   (if (some? (clojure.core/get-in config-map ks))
     (clojure.core/get-in config-map ks)
     (throw (ex-info (format "No config found for path %s\nDid you configure your secrets.edn file?" ks)
-                    {:ks ks, :profile (profile), :config config-map}))))
+                    {:ks ks, :profile (profile)}))))
 
 (defn config []
   (aero/read-config (io/resource "config.edn") {:profile (profile)}))

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -15,7 +15,7 @@
   (if (some? (clojure.core/get-in config-map ks))
     (clojure.core/get-in config-map ks)
     (throw (ex-info (format "No config found for path %s\nDid you configure your secrets.edn file?" ks)
-                    {:ks ks, :profile (profile)}))))
+                    {:ks ks, :profile (profile), :config config-map}))))
 
 (defn config []
   (aero/read-config (io/resource "config.edn") {:profile (profile)}))
@@ -57,7 +57,9 @@
               (get-in config [:secrets :sentry :dsn]))))
 
 (comment
-  (config)
+  (:cljdoc/server (config))
+
+  (sentry-dsn)
 
   (get-in (config)
           [:cljdoc/hardcoded (cljdoc.util/artifact-id project) :cljdoc.api/namespaces])

--- a/src/cljdoc/config.clj
+++ b/src/cljdoc/config.clj
@@ -51,6 +51,11 @@
   ([] (version (config)))
   ([config] (get-in config [:cljdoc/version])))
 
+(defn sentry-dsn
+  ([] (sentry-dsn (config)))
+  ([config] (when (get-in config [:cljdoc/server :enable-sentry?])
+              (get-in config [:secrets :sentry :dsn]))))
+
 (comment
   (config)
 

--- a/src/cljdoc/util/sentry.clj
+++ b/src/cljdoc/util/sentry.clj
@@ -1,0 +1,41 @@
+(ns cljdoc.util.sentry
+  (:require [cljdoc.config :as cfg]
+            [raven-clj.core :as raven]
+            [raven-clj.interfaces :as interfaces]
+            [clojure.tools.logging :as log]))
+
+(defn capture [{:keys [req ex]}]
+  (if (cfg/sentry-dsn)
+    (let [payload (cond-> {:release (cfg/version)}
+                             ex  (interfaces/stacktrace ex ["cljdoc"])
+                             req (interfaces/http req identity))
+          sentry-response (raven/capture (cfg/sentry-dsn) payload)]
+      (when-not (= 200 (:status sentry-response))
+        (log/errorf "Failed to log error to Sentry %s %s"
+                    (:status sentry-response) (:body sentry-response))))
+    (log/warn "DSN missing: Not tracking error in Sentry")))
+
+(def interceptor
+  {:name  ::interceptor
+   :error (fn sentry-intercept [ctx ex-info]
+            (capture {:ex ex-info :req (:request ctx)})
+            (throw ex-info))})
+
+(comment
+  (raven/parse-dsn dsn)
+
+  (capture {:ex cljdoc.server.pedestal/-error-ex
+            :req (:request cljdoc.server.pedestal/-error-ctx)})
+
+
+  (clojure.pprint/pprint
+   (-> {}
+       (interfaces/stacktrace cljdoc.server.pedestal/-error-ex)
+       (interfaces/http (:request cljdoc.server.pedestal/-error-ctx)
+                        identity)))
+
+  (identity cljdoc.server.pedestal/-error-ex)
+
+  )
+
+

--- a/src/cljdoc/util/sentry.clj
+++ b/src/cljdoc/util/sentry.clj
@@ -30,22 +30,3 @@
    :error (fn sentry-intercept [ctx ex-info]
             (capture {:ex ex-info :req (:request ctx)})
             (throw ex-info))})
-
-(comment
-  (raven/parse-dsn dsn)
-
-  (capture {:ex cljdoc.server.pedestal/-error-ex
-            :req (:request cljdoc.server.pedestal/-error-ctx)})
-
-
-  (clojure.pprint/pprint
-   (-> {}
-       (interfaces/stacktrace cljdoc.server.pedestal/-error-ex)
-       (interfaces/http (:request cljdoc.server.pedestal/-error-ctx)
-                        identity)))
-
-  (identity cljdoc.server.pedestal/-error-ex)
-
-  )
-
-


### PR DESCRIPTION
Fixes #48

This adds error tracking via [Sentry](https://sentry.io/). Disabled in non-prod profile.