### PR TITLE
Offline docs

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -34,6 +34,7 @@
     [org.jsoup/jsoup "1.11.3"]
     [digest "1.4.8"]
     [tea-time "1.0.0"]
+    [me.raynes/fs "1.4.6"]
 
     [io.pedestal/pedestal.service       "0.5.3"]
     [io.pedestal/pedestal.jetty         "0.5.3"]

--- a/resources/public/cljdoc.css
+++ b/resources/public/cljdoc.css
@@ -98,9 +98,3 @@
   bottom: 0;
   left: -2rem;
 }
-
-/** Namespace Page Code Blocks -------------------------------------- **/
-
-.ns-page .def-block .hljs {
-  padding: inherit;
-}

--- a/src/cljdoc/cache.clj
+++ b/src/cljdoc/cache.clj
@@ -1,4 +1,5 @@
 (ns cljdoc.cache
+  "Functions to operate on cache bundles"
   (:require [cljdoc.spec]))
 
 (defn namespaces

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -135,6 +135,21 @@
           (-> (set (map :platform platf-defs))
               (humanize-supported-platforms))])])]])
 
+(defn namespace-overview
+  [ns-url ns defs]
+  [:div
+   [:a.link.black
+    {:href ns-url}
+    [:h2 ns
+     [:img.ml2 {:src "https://icon.now.sh/chevron/12/357edd"}]]]
+   (some-> meta :doc render-doc-string)
+   [:ul.list.pl0
+    (for [d defs]
+      [:li.dib.mr3.mb2
+       [:a.link.blue
+        {:href (str ns-url "#" (:name d))}
+        (:name d)]])]])
+
 (defn sub-namespace-overview-page
   [{:keys [ns-entity namespaces defs top-bar-component article-list-component namespace-list-component]}]
   [:div.ns-page
@@ -145,28 +160,17 @@
    (layout/main-container
     {:offset "16rem"}
     [:div.w-80-ns.pv5
-     (for [[ns meta] (->> namespaces
-                          (filter #(.startsWith (:name %) (:namespace ns-entity)))
-                          (map #(dissoc % :platform))
-                          (set)
-                          (ns-tree/index-by :name); see PLATF_SUPPORT
-                          (sort-by key))
-           :let [ns-url (routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace ns))
+     (for [meta (->> namespaces
+                     (filter #(.startsWith (:name %) (:namespace ns-entity)))
+                     (map #(dissoc % :platform)); see PLATF_SUPPORT
+                     (set)
+                     (sort-by key))
+           :let [ns (:name meta)
+                 ns-url (routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace ns))
                  defs (->> defs
                            (filter #(= ns (:namespace %)))
                            (sort-by :name))]]
-       [:div
-        [:a.link.black
-         {:href ns-url}
-         [:h2 ns
-          [:img.ml2 {:src "https://icon.now.sh/chevron/12/357edd"}]]]
-        (some-> meta :doc render-doc-string)
-        [:ul.list.pl0
-         (for [d defs]
-           [:li.dib.mr3.mb2
-            [:a.link.blue
-             {:href (str ns-url "#" (:name d))}
-             (:name d)]])]])])])
+       (namespace-overview ns-url meta defs))])])
 
 (defn namespace-page [{:keys [ns-entity ns-data defs scm-info top-bar-component article-list-component namespace-list-component]}]
   (cljdoc.spec/assert :cljdoc.spec/namespace-entity ns-entity)

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -164,7 +164,7 @@
                      (filter #(.startsWith (:name %) (:namespace ns-entity)))
                      (map #(dissoc % :platform)); see PLATF_SUPPORT
                      (set)
-                     (sort-by key))
+                     (sort-by :name))
            :let [ns (:name meta)
                  ns-url (routes/url-for :artifact/namespace :path-params (assoc ns-entity :namespace ns))
                  defs (->> defs

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -14,7 +14,7 @@
   [args-str]
   {:pre [(string? args-str)]}
   [:pre
-   [:code.db.mb2 {:class "language-clojure"}
+   [:code.db.mb2.pa0 {:class "language-clojure"}
     (zp/zprint-str args-str {:parse-string? true :width 70})]])
 
 (defn render-doc-string [doc-str]

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -32,7 +32,7 @@
     (cljdoc.spec/assert :cljdoc.spec/def-full def-meta)
     [:div.def-block
      [:hr.mv3.b--black-10]
-     [:h4.def-block-title
+     [:h4.def-block-title.mv0.pv3
       {:name (:name def-meta), :id (:name def-meta)}
       (:name def-meta)
       (when-not (= :var (:type def-meta))

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -142,7 +142,7 @@
    [:a.link.black
     {:href ns-url}
     [:h2
-     {:data-cljdoc-type :namespace}
+     {:data-cljdoc-type "namespace"}
      (:name ns-meta)
      [:img.ml2 {:src "https://icon.now.sh/chevron/12/357edd"}]]]
    (some-> ns-meta :doc render-doc-string)
@@ -150,7 +150,7 @@
     (for [d defs]
       [:li.dib.mr3.mb2
        [:a.link.blue
-        {:data-cljdoc-type (if (:arglists d) :fn (:type d))
+        {:data-cljdoc-type (name (if (:arglists d) :function (:type d)))
          :href (str ns-url "#" (:name d))}
         (:name d)]])]])
 

--- a/src/cljdoc/render/api.clj
+++ b/src/cljdoc/render/api.clj
@@ -136,18 +136,22 @@
               (humanize-supported-platforms))])])]])
 
 (defn namespace-overview
-  [ns-url ns defs]
+  [ns-url ns-meta defs]
+  {:pre [(:name ns-meta) (string? ns-url) (seq defs)]}
   [:div
    [:a.link.black
     {:href ns-url}
-    [:h2 ns
+    [:h2
+     {:data-cljdoc-type :namespace}
+     (:name ns-meta)
      [:img.ml2 {:src "https://icon.now.sh/chevron/12/357edd"}]]]
-   (some-> meta :doc render-doc-string)
+   (some-> ns-meta :doc render-doc-string)
    [:ul.list.pl0
     (for [d defs]
       [:li.dib.mr3.mb2
        [:a.link.blue
-        {:href (str ns-url "#" (:name d))}
+        {:data-cljdoc-type (if (:arglists d) :fn (:type d))
+         :href (str ns-url "#" (:name d))}
         (:name d)]])]])
 
 (defn sub-namespace-overview-page

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -13,8 +13,8 @@
                  [:title (:title opts)]
                  [:meta {:charset "utf-8"}]
                  (hiccup.page/include-css
-                   "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"
                    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/github-gist.min.css"
+                   "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"
                    "/cljdoc.css")]
                 [:div.sans-serif
                  contents]

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -2,8 +2,21 @@
   "Components to layout cljdoc pages"
   (:require [cljdoc.server.routes :as routes]
             [cljdoc.util :as util]
-            [hiccup.core :as hiccup]
+            [clojure.string :as string]
+            [hiccup2.core :as hiccup]
             [hiccup.page]))
+
+(defn highlight-js []
+  [:div
+   (hiccup.page/include-js
+    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/highlight.min.js"
+    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure.min.js"
+    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure-repl.min.js")
+   [:script
+    (->> ["hljs.initHighlightingOnLoad();"
+          "hljs.registerLanguage('cljs', function (hljs) { return hljs.getLanguage('clj') });"]
+         (string/join "\n")
+         (hiccup/raw))]])
 
 (defn page [opts contents]
   (hiccup/html {:mode :html}
@@ -18,12 +31,8 @@
                    "/cljdoc.css")]
                 [:div.sans-serif
                  contents]
-                (hiccup.page/include-js
-                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/highlight.min.js"
-                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure.min.js"
-                  "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/languages/clojure-repl.min.js"
-                  "/cljdoc.js")
-                [:script "hljs.initHighlightingOnLoad();"]]))
+                (hiccup.page/include-js "/cljdoc.js")
+                (highlight-js)]))
 
 (defn sidebar-title [title]
   [:h4.ttu.f7.fw5.tracked.gray title])

--- a/src/cljdoc/render/layout.clj
+++ b/src/cljdoc/render/layout.clj
@@ -47,7 +47,7 @@
     (into [:div.absolute.top-0.bottom-0.left-0.right-0.overflow-y-scroll.ph4-ns.ph2.main-scroll-view]
           content)])
 
-(defn top-bar [cache-id version-meta]
+(defn top-bar [cache-id scm-url]
   [:nav.pv2.ph3.pv3-ns.ph4-ns.bb.b--black-10.flex.items-center
    [:a.dib.v-mid.link.dim.black.b.f6.mr3 {:href (routes/url-for :artifact/version :path-params cache-id)}
     (util/clojars-id cache-id)]
@@ -65,7 +65,7 @@
      [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "project" :name "project" :value (str (:group-id cache-id) "/" (:artifact-id cache-id))}]
      [:input.pa2.mr2.br2.ba.outline-0.blue {:type "hidden" :id "version" :name "version" :value (:version cache-id)}]
      [:input.f7.white.hover-near-white.outline-0.bn.bg-white {:type "submit" :value "rebuild"}]]
-    (if-let [scm-url (-> version-meta :scm :url)]
+    (if scm-url
       [:a.link.dim.gray.f6.tr
        {:href scm-url}
        [:img.v-mid.mr2 {:src "https://icon.now.sh/github"}]

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -1,0 +1,225 @@
+(ns cljdoc.render.offline
+  "Rendering code for offline bundles.
+
+  While more reuse would be possible this is intentionally
+  kept somewhat separately as DOM stability is more important
+  for tools like Dash etc."
+  (:require [cljdoc.render.layout :as layout]
+            [cljdoc.render.api :as api]
+            [cljdoc.doc-tree :as doctree]
+            [cljdoc.spec :as cljdoc-spec]
+            [cljdoc.util :as util]
+            [cljdoc.util.fixref :as fixref]
+            [cljdoc.render.rich-text :as rich-text]
+            [clojure.string :as string]
+            [clojure.java.io :as io]
+            [me.raynes.fs.compression :as fs-compression]
+            [hiccup2.core :as hiccup]
+            [hiccup.page])
+  (:import (java.nio.file Files)))
+
+(defn ns-url [ns]
+  (str "api/" ns ".html"))
+
+(defn article-url
+  [slug-path]
+  {:pre [(string? (first slug-path))]}
+  ;; WARN this could lead to overwriting files but nesting
+  ;; directories complicates linking between files a lot and
+  ;; so taking a shortcut here.
+  (str "doc/" (string/join "-" slug-path) ".html"))
+
+(defn top-bar [version-entity scm-url sub-page?]
+  [:nav.pv2.ph3.pv3-ns.ph4-ns.bb.b--black-10.flex.items-center
+   [:a.dib.v-mid.link.dim.black.b.f6.mr3
+    {:href (if sub-page? ".." "#")}
+    (util/clojars-id version-entity)]
+   [:span.dib.v-mid.gray.f6.mr3
+    (:version version-entity)]
+   [:a.link.blue.ml3 {:href (if sub-page? "../index.html#namespaces" "#namespaces")} "Namespaces"]
+   [:a.link.blue.ml3 {:href (if sub-page? "../index.html#articles" "#articles")} "Articles"]
+   [:div.tr
+    {:style {:flex-grow 1}}
+    (when scm-url
+      [:a.link.dim.gray.f6.tr
+       {:href scm-url}
+       [:img.v-mid.mr2 {:src "https://icon.now.sh/github"}]
+       [:span.dib (util/gh-coordinate scm-url)]])]])
+
+(defn page [{:keys [version-entity namespace article-title scm-url]} contents]
+  (let [sub-page? (or namespace article-title)]
+    (hiccup/html {:mode :html}
+                 (hiccup.page/doctype :html5)
+                 [:html {}
+                  [:head
+                   [:title
+                    (str
+                     (some-> sub-page? (str " — "))
+                     (util/clojars-id version-entity) " v"
+                     (:version version-entity))]
+                   [:meta {:charset "utf-8"}]
+                   (hiccup.page/include-css
+                    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/github-gist.min.css"
+                    "https://unpkg.com/tachyons@4.9.0/css/tachyons.min.css"
+                    (if sub-page? "../cljdoc.css" "cljdoc.css"))]
+                  [:div.sans-serif
+                   (top-bar version-entity scm-url sub-page?)
+                   [:div.absolute.bottom-0.left-0.right-0.overflow-scroll
+                    {:style {:top "52px"}}
+                    [:div.mw7.center.pa2.pb4
+                     contents]]]
+                  (layout/highlight-js)])))
+
+(defn article-toc
+  "Very similar to `doc-tree-view` but uses the offline-docs
+  link/url generation mechanism"
+  [doc-tree]
+  (->> doc-tree
+       (map (fn [doc-page]
+              (let [slug-path (-> doc-page :attrs :slug-path)]
+                [:li.mv1
+                 (if (-> doc-page :attrs :cljdoc.doc/source-file)
+                   [:a.link.blue.hover-dark-blue.dib
+                    {:href  (article-url slug-path)}
+                    (:title doc-page)]
+                   [:span (:title doc-page)])
+                 (some-> doc-page :children seq article-toc)])))
+       (into [:ol])))
+
+(defn index-page [{:keys [cache-contents]}]
+  [:div
+   (when (-> cache-contents :version :doc)
+     [:div
+      [:h1.mv0.pv3 {:id "articles"} "Articles"]
+      (article-toc (doctree/add-slug-path (-> cache-contents :version :doc)))])
+
+   [:h1.mv0.pv3 {:id "namespaces"} "Namespaces"]
+   (for [ns (->> (:namespaces cache-contents)
+                 (group-by :name) ;PLATF_SUPPORT
+                 (vals)
+                 (map #(apply merge %))
+                 (sort-by :name))
+         :let [ns-url (ns-url (:name ns))
+               defs (->> (:defs cache-contents)
+                         (filter #(= (:name ns) (:namespace %)))
+                         (map #(dissoc % :platform))
+                         (set) ; PLATF_SUPPORT
+                         (sort-by :name))]]
+     (api/namespace-overview ns-url ns defs))])
+
+(defn doc-page [doc-p fix-opts]
+  [:div
+   [:div.markdown.lh-copy.pv4
+    (hiccup/raw
+     (fixref/fix (-> doc-p :attrs :cljdoc.doc/source-file)
+                 (or (some-> doc-p :attrs :cljdoc/markdown rich-text/markdown-to-html)
+                     (some-> doc-p :attrs :cljdoc/asciidoc rich-text/asciidoc-to-html))
+                 fix-opts))]])
+
+(defn ns-page [ns defs {:keys [scm-base file-mapping]}]
+  [:div
+   [:h1 (:name ns)]
+   (some-> ns :doc api/render-doc-string)
+   (for [[def-name platf-defs] (->> defs
+                                    (group-by :name)
+                                    (sort-by key))
+         :let [def-meta (first platf-defs)]] ;PLATF_SUPPORT
+     (api/def-block platf-defs (when file-mapping
+                                 (str scm-base (get file-mapping (:file def-meta)) "#L" (:line def-meta)))))])
+
+(defn docs-files
+  "Return a list of [file-path content] pairs describing a zip archive.
+
+  Content may be a java.io.File or hiccup.util.RawString"
+  [{:keys [cache-contents cache-id] :as cache-bundle}]
+  (cljdoc-spec/assert :cljdoc.spec/cache-bundle cache-bundle)
+  (let [doc-tree     (doctree/add-slug-path (-> cache-contents :version :doc))
+        scm-info     (-> cache-contents :version :scm)
+        blob         (or (:name (:tag scm-info)) (:commit scm-info))
+        scm-base     (str (:url scm-info) "/blob/" blob "/")
+        file-mapping (when (:files scm-info)
+                       (fixref/match-files
+                        (keys (:files scm-info))
+                        (set (keep :file (-> cache-contents :defs)))))
+        flat-doctree (-> doc-tree doctree/flatten*)
+        uri-map (->> flat-doctree
+                       (map (fn [d]
+                              [(-> d :attrs :cljdoc.doc/source-file)
+                               (article-url (-> d :attrs :slug-path))]))
+                       (into {}))
+        page'   (fn [type title contents]
+                  (page {:version-entity cache-id
+                         :scm-url (-> cache-contents :version :scm :url)
+                         type title}
+                        contents))]
+
+
+    (reduce
+     into
+     [[["cljdoc.css" (io/file (io/resource "public/cljdoc.css"))]
+       ["index.html" (->> (index-page cache-bundle)
+                          (page' nil nil))]]
+
+      ;; Documentation Pages / Articles
+      (for [doc-p (filter #(-> % :attrs :cljdoc.doc/source-file) flat-doctree)]
+        [(article-url (-> doc-p :attrs :slug-path))
+         (->> (doc-page doc-p {:scm scm-info :uri-map uri-map})
+              (page' :article-title (:title doc-p)))])
+
+      ;; Namespace Pages
+      (for [ns-emap (cljdoc.cache/namespaces cache-bundle)
+            :let [ns-data (first (filter #(= (:namespace ns-emap) (:name %)) ;PLATF_SUPPORT
+                                         (:namespaces cache-contents)))
+                  defs    (filter #(= (:namespace ns-emap)
+                                      (:namespace %))
+                                  (:defs cache-contents))]]
+        [(ns-url (:namespace ns-emap))
+         (->> (ns-page ns-data defs {:scm-base scm-base :file-mapping file-mapping})
+              (page' :namespace (:name ns-data)))])])))
+
+(defn zip-stream [{:keys [cache-id] :as cache-bundle}]
+  (let [prefix (str (-> cache-id :artifact-id)
+                    "-" (-> cache-id :version)
+                    "/")]
+    (->> (docs-files cache-bundle)
+         (map (fn [[k v]]
+                [(str prefix k)
+                 (cond
+                   (instance? java.io.File v)         (Files/readAllBytes (.toPath v))
+                   (instance? hiccup.util.RawString v) (.getBytes (str v))
+                   :else (throw (Exception. (str "Unsupported value " (class v)))))]))
+         (fs-compression/make-zip-stream))))
+
+(comment
+  (require '[cljdoc.storage.api :as storage]
+           '[clojure.inspector :as i])
+
+  (i/inspect-tree --c)
+
+  (def --c (storage/bundle-docs (storage/->GrimoireStorage (io/file "data" "grimoire"))
+                                #_{:group-id "reagent" :artifact-id "reagent" :version "0.8.1"}
+                                #_{:group-id "re-frame" :artifact-id "re-frame" :version "0.10.5"}
+                                {:group-id "manifold" :artifact-id "manifold" :version "0.1.6"}))
+
+  (defn hiccup-raw-str? [x]
+    (instance? hiccup.util.RawString x))
+
+  (zip-stream --c)
+
+  (->> (take 2 (docs-files --c))
+       (map (fn [[k v]]
+              [(str (-> --c :cache-id :artifact-id)
+                    "-" (-> --c :cache-id :version)
+                    "/" k)
+               (cond
+                 (instance?  java.io.File v)         (Files/readAllBytes (.toPath v))
+                 (instance? hiccup.util.RawString v) (.getBytes (str v))
+                 :else (throw (Exception. (str "Unsupported value " (class v)))))]))
+       (fs-compression/zip "offline-docs.zip"))
+
+  (do (cljdoc.util/delete-directory! (io/file "offline-docs"))
+      (write-docs* --c (io/file "offline-docs")))
+
+ 
+
+  )

--- a/src/cljdoc/render/offline.clj
+++ b/src/cljdoc/render/offline.clj
@@ -8,6 +8,7 @@
             [cljdoc.render.api :as api]
             [cljdoc.doc-tree :as doctree]
             [cljdoc.spec :as cljdoc-spec]
+            [cljdoc.cache :as cljdoc-cache]
             [cljdoc.util :as util]
             [cljdoc.util.fixref :as fixref]
             [cljdoc.render.rich-text :as rich-text]
@@ -167,7 +168,7 @@
               (page' :article-title (:title doc-p)))])
 
       ;; Namespace Pages
-      (for [ns-emap (cljdoc.cache/namespaces cache-bundle)
+      (for [ns-emap (cljdoc-cache/namespaces cache-bundle)
             :let [ns-data (first (filter #(= (:namespace ns-emap) (:name %)) ;PLATF_SUPPORT
                                          (:namespaces cache-contents)))
                   defs    (filter #(= (:namespace ns-emap)

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -111,8 +111,7 @@
                                :doc-html (fixref/fix (-> doc-p :attrs :cljdoc.doc/source-file)
                                                      doc-html
                                                      {:scm (:scm (:version cache-contents))
-                                                      :artifact-entity cache-id
-                                                      :flattened-doctree (doctree/flatten* doc-tree)})})
+                                                      :uri-map (fixref/uri-mapping cache-id (doctree/flatten* doc-tree))})})
            (articles/doc-overview {:top-bar-component (layout/top-bar cache-id (:version cache-contents))
                                    :doc-tree-component (articles/doc-tree-view cache-id doc-tree doc-slug-path)
                                    :namespace-list-component (api/namespace-list {} (cljdoc.cache/namespaces cache-bundle))

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -4,7 +4,7 @@
             [cljdoc.render.layout :as layout]
             [cljdoc.render.articles :as articles]
             [cljdoc.render.api :as api]
-            [cljdoc.util]
+            [cljdoc.util :as util]
             [cljdoc.util.fixref :as fixref]
             [cljdoc.cache]
             [cljdoc.spec]
@@ -12,11 +12,6 @@
             [clojure.string :as string]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io]))
-
-(defn clojars-id [{:keys [group-id artifact-id] :as cache-id}]
-  (if (= group-id artifact-id)
-    artifact-id
-    (str group-id "/" artifact-id)))
 
 (defn render-to [opts hiccup ^java.io.File file]
   (log/info "Writing" (clojure.string/replace (.getPath file) #"^.+grimoire-html" "grimoire-html"))
@@ -59,7 +54,7 @@
         artifact-entity (assoc cache-id :artifact-id artifact-id)
         big-btn-link :a.link.blue.ph3.pv2.bg-lightest-blue.hover-dark-blue.br2]
     (->> [:div.pa4-ns.pa2
-          [:h1 (clojars-id artifact-entity)]
+          [:h1 (util/clojars-id artifact-entity)]
           [:span.db "Known versions on cljdoc:"]
           [:ol.list.pl0.pv3
            (for [v (->> (:versions cache-contents)
@@ -79,7 +74,7 @@
                  [big-btn-link
                   {:href (routes/url-for :artifact/index :path-params (assoc cache-id :artifact-id a))}
                   a]])]])]
-         (layout/page {:title (str (clojars-id artifact-entity) " — cljdoc")}))))
+         (layout/page {:title (str (util/clojars-id artifact-entity) " — cljdoc")}))))
 
 (defmethod render :artifact/version
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
@@ -89,7 +84,7 @@
          (articles/article-list
           (articles/doc-tree-view cache-id (doctree/add-slug-path (-> cache-contents :version :doc)) []))
          (api/namespace-list {} (cljdoc.cache/namespaces cache-bundle)))]
-       (layout/page {:title (str (clojars-id cache-id) " " (:version cache-id))})))
+       (layout/page {:title (str (util/clojars-id cache-id) " " (:version cache-id))})))
 
 (defmethod render :artifact/doc
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
@@ -117,7 +112,7 @@
                                    :namespace-list-component (api/namespace-list {} (cljdoc.cache/namespaces cache-bundle))
                                    :cache-id cache-id
                                    :doc-tree (doctree/get-subtree doc-tree doc-slug-path)}))
-         (layout/page {:title (str (:title doc-p) " — " (clojars-id cache-id) " " (:version cache-id))}))))
+         (layout/page {:title (str (:title doc-p) " — " (util/clojars-id cache-id) " " (:version cache-id))}))))
 
 (defmethod render :artifact/namespace
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
@@ -146,7 +141,7 @@
                                                    {:ns-entity ns-emap
                                                     :namespaces (:namespaces cache-contents)
                                                     :defs (:defs cache-contents)})))
-         (layout/page {:title (str (:namespace ns-emap) " — " (clojars-id cache-id) " " (:version cache-id))}))))
+         (layout/page {:title (str (:namespace ns-emap) " — " (util/clojars-id cache-id) " " (:version cache-id))}))))
 
 (defn write-docs* [{:keys [cache-contents cache-id] :as cache-bundle} ^java.io.File out-dir]
   (cljdoc.spec/assert :cljdoc.spec/cache-bundle cache-bundle)

--- a/src/cljdoc/renderers/html.clj
+++ b/src/cljdoc/renderers/html.clj
@@ -84,7 +84,7 @@
 (defmethod render :artifact/version
   [_ route-params {:keys [cache-id cache-contents] :as cache-bundle}]
   (->> [:div
-        (layout/top-bar cache-id (:version cache-contents))
+        (layout/top-bar cache-id (-> cache-contents :version :scm :url))
         (layout/sidebar
          (articles/article-list
           (articles/doc-tree-view cache-id (doctree/add-slug-path (-> cache-contents :version :doc)) []))
@@ -103,7 +103,7 @@
         doc-html (or (some-> doc-p :attrs :cljdoc/markdown rich-text/markdown-to-html)
                      (some-> doc-p :attrs :cljdoc/asciidoc rich-text/asciidoc-to-html))]
     (->> (if doc-html
-           (articles/doc-page {:top-bar-component (layout/top-bar cache-id (:version cache-contents))
+           (articles/doc-page {:top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
                                :doc-tree-component (articles/doc-tree-view cache-id doc-tree doc-slug-path)
                                :namespace-list-component (api/namespace-list {} (cljdoc.cache/namespaces cache-bundle))
                                :doc-scm-url (str (-> cache-contents :version :scm :url) "/blob/master/"
@@ -112,7 +112,7 @@
                                                      doc-html
                                                      {:scm (:scm (:version cache-contents))
                                                       :uri-map (fixref/uri-mapping cache-id (doctree/flatten* doc-tree))})})
-           (articles/doc-overview {:top-bar-component (layout/top-bar cache-id (:version cache-contents))
+           (articles/doc-overview {:top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
                                    :doc-tree-component (articles/doc-tree-view cache-id doc-tree doc-slug-path)
                                    :namespace-list-component (api/namespace-list {} (cljdoc.cache/namespaces cache-bundle))
                                    :cache-id cache-id
@@ -126,7 +126,7 @@
         defs (filter #(= (:namespace ns-emap) (:namespace %)) (:defs cache-contents))
         ns-data (first (filter #(= (:namespace ns-emap) (:name %)) ;PLATF_SUPPORT
                                (:namespaces cache-contents)))
-        common-params {:top-bar-component (layout/top-bar cache-id (:version cache-contents))
+        common-params {:top-bar-component (layout/top-bar cache-id (-> cache-contents :version :scm :url))
                        :article-list-component (articles/article-list
                                                 (articles/doc-tree-view cache-id
                                                                         (doctree/add-slug-path (-> cache-contents :version :doc))
@@ -150,7 +150,7 @@
 
 (defn write-docs* [{:keys [cache-contents cache-id] :as cache-bundle} ^java.io.File out-dir]
   (cljdoc.spec/assert :cljdoc.spec/cache-bundle cache-bundle)
-  (let [top-bar-comp (layout/top-bar cache-id (:version cache-contents))
+  (let [top-bar-comp (layout/top-bar cache-id (-> cache-contents :version :scm-url))
         doc-tree     (doctree/add-slug-path (-> cache-contents :version :doc))]
 
     ;; Index page for given version

--- a/src/cljdoc/server/routes.clj
+++ b/src/cljdoc/server/routes.clj
@@ -31,7 +31,8 @@
     ["/d/:group-id" :get nop :route-name :group/index]
     ["/d/:group-id/:artifact-id" :get nop :route-name :artifact/index]
     ["/d/:group-id/:artifact-id/:version/doc/*article-slug" :get nop :route-name :artifact/doc]
-    ["/d/:group-id/:artifact-id/:version/api/:namespace" :get nop :route-name :artifact/namespace]})
+    ["/d/:group-id/:artifact-id/:version/api/:namespace" :get nop :route-name :artifact/namespace]
+    ["/download/:group-id/:artifact-id/:version" :get nop :route-name :artifact/offline-bundle]})
 
 (defn info-pages-routes []
   #{["/" :get nop :route-name :home]})

--- a/src/cljdoc/util.clj
+++ b/src/cljdoc/util.clj
@@ -144,3 +144,12 @@
       :contributors       (str base "/graphs/contributors")
       :userguide/articles (str base "/blob/master/doc/userguide/articles.md")
       :userguide/scm-faq  (str base "/blob/master/doc/userguide/faq.md#how-do-i-set-scm-info-for-my-project"))))
+
+(defn strip-common-start-string
+  "Remove the common substring from `s2` that both, `s1`
+  and `s2` start with."
+  [s1 s2]
+  (->> (map vector s1 s2)
+       (take-while #(= (first %) (second %)))
+       (count)
+       (subs s2)))

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -21,7 +21,7 @@
 (defn- anchor-uri? [s]
   (.startsWith s "#"))
 
-(defn- uri-mapping [cache-id docs]
+(defn uri-mapping [cache-id docs]
   (->> docs
        (map (fn [d]
               [(-> d :attrs :cljdoc.doc/source-file)

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -65,12 +65,11 @@
       (str scm-base (rebase file-path src) suffix))))
 
 (defn fix
-  [file-path html-str {:keys [git-ls scm flattened-doctree artifact-entity] :as fix-opts}]
+  [file-path html-str {:keys [git-ls scm uri-map] :as fix-opts}]
   ;; (def fp file-path)
   ;; (def hs html-str)
   ;; (def fo fix-opts)
   (let [doc     (Jsoup/parse html-str)
-        uri-map (uri-mapping artifact-entity flattened-doctree)
         scm-rev (or (:name (:tag scm))
                     (:commit scm))]
     (doseq [broken-link (->> (.select doc "a")

--- a/src/cljdoc/util/fixref.clj
+++ b/src/cljdoc/util/fixref.clj
@@ -54,7 +54,10 @@
     ;; (prn 'from-uri-map  (get uri-map w-o-anchor))
     ;; (prn 'keys-uri-map  (keys uri-map))
     (if-let [from-uri-map (get uri-map w-o-anchor)]
-      (str from-uri-map anchor)
+      (-> (get uri-map file-path)
+          ;; TODO check if relative links will work consistently
+          (util/strip-common-start-string from-uri-map)
+          (str anchor))
       (str scm-base root-relative))))
 
 (defn fix-image

--- a/test/cljdoc/util_test.clj
+++ b/test/cljdoc/util_test.clj
@@ -36,6 +36,9 @@
   (t/is (= (util/normalize-git-url "http://github.com/clojure/clojure")
            "https://github.com/clojure/clojure")))
 
+(t/deftest strip-common-start-string-test
+  (t/is (= "xyz.html" (util/strip-common-start-string "doc/abc.html" "doc/xyz.html"))))
+
 (comment
   (t/run-tests)
 


### PR DESCRIPTION
Sometimes it's very convenient to allow users to view documentation offline, e.g. when on flights or simply for tools like [Dash](http://kapeli.com/dash) or [Zeal](https://zealdocs.org/).

This PR introduces another endpoint:

```
/download/reagent/reagent/0.8.1
```

That will download a zipfile `reagent-0.8.1.zip`. This zip file contains all documentation in a slightly more lean layout and with an overview `index.html` that lists all interesting things.

Until this is deployed you can see some examples here. I would be very happy about any feedback with regards to the bundled docs & the code introducing this change:
 
- [manifold-0.1.6.zip](https://github.com/martinklepsch/cljdoc/files/2144612/manifold-0.1.6.zip)
- [reagent-0.8.1.zip](https://github.com/martinklepsch/cljdoc/files/2144613/reagent-0.8.1.zip)

I also hope that this is another step towards providing additional value over self-hosting documentation, eventually increasing adoption of cljdoc.
 